### PR TITLE
Dynamic thermostate_mode

### DIFF
--- a/app.json
+++ b/app.json
@@ -1570,20 +1570,6 @@
     }
   ],
   "capabilities": {
-    "air_quality": {
-      "type": "string",
-      "title": {
-        "en": "Air quality"
-      },
-      "desc": {
-        "en": "Air quality"
-      },
-      "icon": "./assets/air_quality.svg",
-      "getable": true,
-      "setable": false,
-      "uiComponent": "sensor",
-      "insights": false
-    },
     "alarm_filter": {
       "type": "boolean",
       "title": {

--- a/drivers/BaseDevice.js
+++ b/drivers/BaseDevice.js
@@ -79,9 +79,7 @@ module.exports = class BaseDevice extends Homey.Device {
       }
 
       // Update only, if there are changes on thermostat_mode modes
-      if (
-        availableModes.length !== currentModes.length || !availableModes.every((mode) => currentModes.includes(mode)) || !currentModes.every((mode) => availableModes.includes(mode))
-      ) {
+      if (util.arraysEqualIgnoreOrder(availableModes, currentOptions.values.map((option) => option.id)) === false) {
         const newOptions = {
           values: availableModes.map((mode) => ({
             id: mode,

--- a/drivers/BaseDevice.js
+++ b/drivers/BaseDevice.js
@@ -65,7 +65,10 @@ module.exports = class BaseDevice extends Homey.Device {
       // Modes reported by the remote device
       const remoteModes = util.getModes(capabilities) || [];
 
-      const availableModes = Array.from(new Set([...defaultModes, ...remoteModes]));
+      const availableModes = [
+        ...defaultModes,
+        ...remoteModes.filter((mode) => !defaultModes.includes(mode))
+      ];
 
       // Fetch current options (may throw if not set yet, so wrap safely)
       let currentOptions;
@@ -75,10 +78,10 @@ module.exports = class BaseDevice extends Homey.Device {
         currentOptions = { values: [] };
       }
 
-      const currentModes = (currentOptions.values || []).map((v) => v.id);
-
-      // Update if there are changes on thermostat_mode modes
-      if (availableModes.length !== currentModes.length || !availableModes.every((mode) => currentModes.includes(mode))) {
+      // Update only, if there are changes on thermostat_mode modes
+      if (
+        availableModes.length !== currentModes.length || !availableModes.every((mode) => currentModes.includes(mode)) || !currentModes.every((mode) => availableModes.includes(mode))
+      ) {
         const newOptions = {
           values: availableModes.map((mode) => ({
             id: mode,

--- a/drivers/BaseDevice.js
+++ b/drivers/BaseDevice.js
@@ -59,6 +59,37 @@ module.exports = class BaseDevice extends Homey.Device {
   }
 
   async onRemoteCapabilitiesReceived(capabilities) {
+    // Adjust modes for thermostat_mode
+    if (capabilities.modes !== undefined && this.hasCapability('thermostat_mode') === true) {
+      const defaultModes = ['auto', 'heat', 'cool', 'off'];
+      // Modes reported by the remote device
+      const remoteModes = util.getModes(capabilities) || [];
+
+      const availableModes = Array.from(new Set([...defaultModes, ...remoteModes]));
+
+      // Fetch current options (may throw if not set yet, so wrap safely)
+      let currentOptions;
+      try {
+        currentOptions = this.getCapabilityOptions('thermostat_mode');
+      } catch (err) {
+        currentOptions = { values: [] };
+      }
+
+      const currentModes = (currentOptions.values || []).map((v) => v.id);
+
+      // Update if there are changes on thermostat_mode modes
+      if (availableModes.length !== currentModes.length || !availableModes.every((mode) => currentModes.includes(mode))) {
+        const newOptions = {
+          values: availableModes.map((mode) => ({
+            id: mode,
+            title: this.homey.__(`thermostat_mode.${mode}`)
+          }))
+        };
+        await this.setCapabilityOptions('thermostat_mode', newOptions);
+        this.log('Updated thermostat_mode options ->', availableModes);
+      }
+    }
+
     // Add Sensibo device model specific measurement capabilities, if available and not yet added.
     if (capabilities.measurements.tvoc !== undefined && this.hasCapability('measure_tvoc') === false) {
       await this.addCapability('measure_tvoc');
@@ -185,7 +216,7 @@ module.exports = class BaseDevice extends Homey.Device {
           if (result.productModel === 'pure') {
             const level_aqi = util.LEVEL_AQI[result.measurements.pm25];
             if (level_aqi) {
-              await this.updateIfChanged('level_aqi', level_aqi)
+              await this.updateIfChanged('level_aqi', level_aqi);
             }
           }
           if (result.productModel === 'elements') {

--- a/lib/util.js
+++ b/lib/util.js
@@ -170,6 +170,11 @@ const toCelsius = (temperature) => {
   return Math.round(((temperature - 32) * 5) / 9);
 };
 
+const arraysEqualIgnoreOrder = (a, b) => {
+  return a.length === b.length && a.every(item => b.includes(item)) && b.every(item => a.includes(item));
+};
+
+
 module.exports = {
   sleep,
   randomDelay,
@@ -184,5 +189,6 @@ module.exports = {
   getAllLights,
   LEVEL_AQI,
   toFahrenheit,
-  toCelsius
+  toCelsius,
+  arraysEqualIgnoreOrder
 };

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,5 +12,13 @@
     "failed_to_retrieve_devices": "Failed to retrieve devices.",
     "no_devices": "No devices were found.",
     "light_not_supported": "Light is not supported for this device."
+  },
+  "thermostat_mode": {
+    "cool": "Cool",
+    "heat": "Heat",
+    "auto": "Automatic",
+    "off": "Off",
+    "dry": "Dry",
+    "fan": "Fan Only"
   }
 }


### PR DESCRIPTION
Update thermostate_mode dynamically based on the remote capabilities. This should allow support for 'dry' and 'fan' modes in addition to the Homey defaults when available.